### PR TITLE
Cache data to reduce the number of API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Cerberus watches the Kubernetes/OpenShift clusters for dead nodes, system compon
 ### Install the dependencies
 ```
 $ pip3 install -r requirements.txt
+
+Cerberus uses redis to cache data in order to avoid overloading API server as well reduce the time it takes to run the checks each iteration. The redis server needs to be installed depending on the distribution and the details like host and port needs to be specified in the config as described in the usage section. Here are the commands to install redis on a Centos/Fedora/RHEL distribution:
+
+$ yum install -y redis
+$ systemctl start redis
+
+**TODO**: Package redis wih Cerberus.
 ```
 
 ### Usage
@@ -52,6 +59,12 @@ tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
     sleep_time: 60                                       # Sleep duration between each iteration
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
+
+redis:
+   host: 127.0.0.1                                       # Redis host
+   port: 6379                                            # Redis port
+   flush_keys: True                                      # Flushes all keys to make sure the cache timeer is set right
+   cache_expiry_time: 1200                               # Redis cache expiry time
 ```
 **NOTE**: The current implementation can monitor only one cluster from one host. It can be used to monitor multiple clusters provided multiple instances of Cerberus are launched on different hosts.
 

--- a/cerberus/redis/client.py
+++ b/cerberus/redis/client.py
@@ -1,0 +1,45 @@
+import logging
+import redis
+
+
+# Initialize redis cli
+def initialize(host, port, flush):
+    global redis_cli
+    logging.info("Initializing redis client")
+    try:
+        redis_cli = redis.StrictRedis(host=host, port=port, decode_responses=True)
+    except Exception as e:
+        logging.error("Cannot connect to redis server on %s:%s, please check" % (host, port))
+        logging.error(e)
+    # Flush all keys
+    if flush:
+        logging.info("Flushing all keys in redis")
+        redis_cli.flushall()
+    else:
+        logging.info("Using the redis database without flushing the existing keys")
+
+
+# Insert keys as sets
+def insert_sets(key, item):
+    redis_cli.sadd(key, item)
+
+
+# Return the items
+def get_set_items(key):
+    return list(redis_cli.smembers(key))
+
+
+# Set expiry date
+def set_expiry(key, time):
+    redis_cli.expire(key, time)
+
+
+# Checks if key exists
+def check_if_exists(key):
+    status = redis_cli.exists(key)
+    return status
+
+
+# Delete key
+def delete_key(key):
+    redis_cli.delete(key)

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,3 +33,9 @@ tunings:
     iterations: 5                                        # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
     sleep_time: 60                                       # Sleep duration between each iteration
     daemon_mode: True                                    # Iterations are set to infinity which means that the cerberus will monitor the resources forever
+
+redis:
+   host: 127.0.0.1                                       # Redis host
+   port: 6379                                            # Redis port
+   flush_keys: True                                      # Flushes all keys to make sure the cache timeer is set right
+   cache_expiry_time: 1200                               # Redis cache expiry time

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ datetime
 configparser
 slackclient
 pyfiglet
+redis


### PR DESCRIPTION
This commit:
- Uses an in-memory database like redis to cache the data as the
  list of the nodes and pods in the system namespaces are not going
  to change very often and re-uses it till they expire. The default
  expiration time is set to 20 minutes but can be adjusted depending
  on the need. So, instead of making an API call to Kubernetes to get
  the list each time, Cerberis will query redis till the cached data
  expires after which it will hit Kube API to get the refreshed/latest
  list. This will reduce the number of API calls per iteration and
  timing by a significant amount.
- The time taken to complete an iteration reduced by 50% with these
  changes on a 50 node cluster.