### PR TITLE
Adding custom-check failures to slack notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Cerberus also consumes [node-problem-detector](https://github.com/kubernetes/nod
 
 
 ### Bring your own checks
-Users can add additional checks to monitor components that are not being monitored by Cerberus and consume it as part of the go/no-go signal.  This can be accomplished by placing relative paths of files containing additional checks under custom_checks in config file. All the checks should be placed within the main function of the file. If the additional checks need to be considered in determining the go/no-go signal of Cerberus, the main function can return a boolean value for the same. However, it's optional to return a value. Refer to [example_check](https://github.com/openshift-scale/cerberus/blob/master/custom_checks/custom_check_sample.py) for an example custom check file.
+Users can add additional checks to monitor components that are not being monitored by Cerberus and consume it as part of the go/no-go signal.  This can be accomplished by placing relative paths of files containing additional checks under custom_checks in config file. All the checks should be placed within the main function of the file. If the additional checks need to be considered in determining the go/no-go signal of Cerberus, the main function can return a boolean value for the same. Having a dict return value of the format {'status':status, 'message':message} shall send signal to Cerberus along with message to be displayed in slack notification. However, it's optional to return a value.
+Refer to [example_check](https://github.com/openshift-scale/cerberus/blob/master/custom_checks/custom_check_sample.py) for an example custom check file.
 
 
 ### Alerts

--- a/cerberus/slack/slack_client.py
+++ b/cerberus/slack/slack_client.py
@@ -64,7 +64,8 @@ def slack_report_cerberus_start(cluster_info, weekday, watcher_slack_member_ID):
 # Report the nodes and namespace failures in slack channel
 def slack_logging(cluster_info, iteration, watch_nodes_status, failed_nodes,
                   watch_cluster_operators_status, failed_operators,
-                  watch_namespaces_status, failed_pods_components):
+                  watch_namespaces_status, failed_pods_components,
+                  custom_checks_status, custom_checks_fail_messages):
     issues = []
     cerberus_report_path = runcommand.invoke("pwd | tr -d '\n'")
     if not watch_nodes_status:
@@ -73,6 +74,8 @@ def slack_logging(cluster_info, iteration, watch_nodes_status, failed_nodes,
         issues.append("*cluster operators: " + ", ".join(failed_operators) + "*")
     if not watch_namespaces_status:
         issues.append("*namespaces: " + ", ".join(list(failed_pods_components.keys())) + "*")
+    if not custom_checks_status:
+        issues.append("*custom_checks: " + ", ".join(custom_checks_fail_messages) + "*")
     issues = "\n".join(issues)
     post_message_in_slack(slack_tag + " %sIn iteration %d at %s, Cerberus "
                           "found issues in: \n%s \nHence, setting the "


### PR DESCRIPTION
Custom check failures are not reported on the slack channel as this functionality hasn't been added yet (Currently Cerberus supports reporting of pods, nodes and cluster operator failures only).

This PR includes the `check_returns` value to the condition that verifies criteria for reporting failure to slack channel.