### PR TITLE
Initialize custom_checks_status

### DIFF
--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -84,6 +84,7 @@ def main(cfg):
         cores_usage_percentage = config["tunings"].get("cores_usage_percentage", 0.5)
         database_path = config["database"].get("database_path", "/tmp/cerberus.db")
         reuse_database = config["database"].get("reuse_database", False)
+        custom_checks_status = False
 
         # Initialize clients and set kube api request chunk size
         if not os.path.isfile(kubeconfig_path):


### PR DESCRIPTION
We've recently hit this issue:

```
2021-03-12 16:32:40,706 [INFO] Exception: local variable 'custom_checks_status' referenced before assignment
```

The variable custom_checks_status needs to be initialized before so that we don't hang when custom_checks is disabled.

