### PR TITLE
fixed unbound variable error

### DIFF
--- a/cerberus/invoke/command.py
+++ b/cerberus/invoke/command.py
@@ -1,12 +1,14 @@
 import subprocess
 import logging
-
+import sys
 
 # Invokes a given command and returns the stdout
 def invoke(command):
+    output = ""
     try:
         output = subprocess.check_output(command, shell=True,
                                          universal_newlines=True)
     except Exception:
         logging.error("Failed to run %s" % (command))
+        sys.exit(1)
     return output

--- a/cerberus/invoke/command.py
+++ b/cerberus/invoke/command.py
@@ -2,6 +2,7 @@ import subprocess
 import logging
 import sys
 
+
 # Invokes a given command and returns the stdout
 def invoke(command):
     output = ""


### PR DESCRIPTION
### Description
Came across `UnboundLocalError: local variable 'output' referenced before assignment` in the recent CI run - https://ec2-52-39-240-23.us-west-2.compute.amazonaws.com:8443/job/cerberus-CI/24/console
### Fixes
