### PR TITLE
Os env

### DIFF
--- a/start_cerberus.py
+++ b/start_cerberus.py
@@ -92,7 +92,9 @@ def main(cfg):
 
         # Initialize clients and set kube api request chunk size
         if not os.path.isfile(kubeconfig_path):
-            kubeconfig_path = None
+            logging.error("Proper kubeconfig not set, please set proper kubeconfig path")
+            sys.exit(1)
+        os.environ["KUBECONFIG"] = str(kubeconfig_path)
         logging.info("Initializing client to talk to the Kubernetes cluster")
         kubecli.initialize_clients(kubeconfig_path, request_chunk_size, cmd_timeout)
 


### PR DESCRIPTION
### Description
Adding environment variable to set local kubeconfig path so when we run "oc" or "kubectl" commands it runs them on the proper cluster set in the config not the cluster set at the machines KUBECONFIG 

### Fixes
https://github.com/cloud-bulldozer/cerberus/issues/148